### PR TITLE
Wrapped retriever.release() in try catch for Android SDK 33

### DIFF
--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -189,7 +189,12 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
         }
   
         Bitmap image = retriever.getFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
-        retriever.release();
+        try{
+            retriever.release();
+        } catch (Exception e) {
+            //nothing
+        }
+
         if (image == null) {
             throw new IllegalStateException("File doesn't exist or not supported");
         }


### PR DESCRIPTION
Wrapped retriever.release() in try catch as the release breaks on Android SDK 33